### PR TITLE
修复“decodeawtransaction”笔误

### DIFF
--- a/ch06.md
+++ b/ch06.md
@@ -19,7 +19,7 @@
 
 在幕后，实际的交易看起来与典型的区块浏览器提供的交易非常不同。 事实上，我们在各种比特币应用程序用户界面中看到的大多数高级结构并不存在于比特币系统中。
 
-我们可以使用Bitcoin Core的命令行界面（getrawtransaction和decodeawtransaction）来检索Alice的“原始”交易，对其进行解码，并查看它包含的内容。 结果如下：
+我们可以使用Bitcoin Core的命令行界面（getrawtransaction和decoderawtransaction）来检索Alice的“原始”交易，对其进行解码，并查看它包含的内容。 结果如下：
 
 Alice的交易被解码后是这个样子：
 
@@ -194,7 +194,7 @@ ff08df09cbe9f6addac960298cad530a863ea8f53982c09db8f6e3813
 
 因为缺乏上下文，这些交易本身似乎不完整。它们在输入中引用了UTXO，但是如果不检索UTXO，我们就无法知道输入的值或其锁定条件。在编写比特币软件时，无论何时，只要是解码交易以验证交易、计算费用或检查解锁脚本，所编的代码就必须首先从区块链中检索引用的UTXO，以便构造输入引用的UTXO隐含但不存在的上下文。例如，要计算支付总额的交易费，必须知道输入和输出值的总和。但是，如果没有检索输入中引用的UTXO，就不能知道这些值。因此，在单个交易中计算交易费用看似简单，实际上涉及多个交易的多个步骤和数据。
 
-我们可以使用与Bitcoin Core相同的命令序列，就像我们在检索Alice的交易（getrawtransaction和decodeawtransaction）时一样。可以得到在前面的输入中引用的UTXO，如下：
+我们可以使用与Bitcoin Core相同的命令序列，就像我们在检索Alice的交易（getrawtransaction和decoderawtransaction）时一样。可以得到在前面的输入中引用的UTXO，如下：
 
 Alice 的UTXO，输入中引用的来自以前的交易：
 


### PR DESCRIPTION
修正一处typo。

我有一本ISBN 978-7-111-62605-3，在阅读时发现了很多错误。刚发现这个仓库，搜了一下，倒发现我发现的其他错误都已被改正了，挺好的。顺便问一下，第六章中的“evaluate”都被翻译成了“评估”是否有点奇怪。在数学中它也有“求值”的意思。比如“Evaluating a script for a P2PKH transaction (part 1 of 2)”，看那图描述的是脚本执行的过程，那evaluate是否可翻译为“执行”？